### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build": "rslib",
     "bump": "npx bumpp",
     "dev": "rslib -w",
-    "prepare": "npm run build",
     "prettier": "prettier --check ./playground ./src ./test *.ts",
     "prettier:fix": "prettier --write ./playground ./src ./test *.ts",
     "test": "rstest",


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove duplicate build commands from `scripts.prepare` where present.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.