### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "rsbuild-plugin-open-graph",
   "version": "1.1.3",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-open-graph",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-open-graph#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-open-graph/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to the repository issues page

## Why
The published npm metadata currently exposes the repository and license, but does not include `homepage` or `bugs` fields. Adding these fields makes the package support links easier to discover from npm and package tooling.

Current npm metadata checked with:

```bash
npm view rsbuild-plugin-open-graph@latest name version repository homepage bugs license --json
```

```json
{
  "name": "rsbuild-plugin-open-graph",
  "version": "1.1.3",
  "repository": "https://github.com/rstackjs/rsbuild-plugin-open-graph",
  "license": "MIT"
}
```

## Validation
- `node -e "const p=require('./package.json'); if(p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-open-graph#readme') throw new Error('bad homepage'); if(!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-open-graph/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({homepage:p.homepage, bugs:p.bugs}, null, 2));"`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`

Note: `pnpm run prettier` currently reports formatting warnings for `src/index.ts` and `src/toSnakeCase.ts`. I reproduced the same result on untouched `upstream/main`, so I left those unrelated source files unchanged in this metadata-only PR.